### PR TITLE
Fixed bug in distances.py when calculating pairs from arbitrary indices

### DIFF
--- a/pyspike/distances.py
+++ b/pyspike/distances.py
@@ -194,7 +194,7 @@ def _generic_profile_multi(spike_trains, pair_distance_func, indices=None):
     assert (indices < len(spike_trains)).all() and (indices >= 0).all(), \
         "Invalid index list."
     # generate a list of possible index pairs
-    pairs = [(i, j) for i in indices for j in indices[i+1:]]
+    pairs = [(indices[i], j) for i in range(len(indices)) for j in indices[i+1:]]
     # start with first pair
     (i, j) = pairs[0]
     average_dist = pair_distance_func(spike_trains[i], spike_trains[j])
@@ -234,7 +234,7 @@ def _multi_distance_par(spike_trains, pair_distance_func, indices=None):
     assert (indices < len(spike_trains)).all() and (indices >= 0).all(), \
         "Invalid index list."
     # generate a list of possible index pairs
-    pairs = [(i, j) for i in indices for j in indices[i+1:]]
+    pairs = [(indices[i], j) for i in range(len(indices)) for j in indices[i+1:]]
     num_pairs = len(pairs)
 
     # start with first pair
@@ -384,7 +384,7 @@ def _generic_distance_matrix(spike_trains, dist_function,
     assert (indices < len(spike_trains)).all() and (indices >= 0).all(), \
         "Invalid index list."
     # generate a list of possible index pairs
-    pairs = [(i, j) for i in indices for j in indices[i+1:]]
+    pairs = [(indices[i], j) for i in range(len(indices)) for j in indices[i+1:]]
 
     distance_matrix = np.zeros((len(indices), len(indices)))
     for i, j in pairs:


### PR DESCRIPTION
Hi Mario,

I was using PySpike to calculate the SPIKE distance for 9 groups of 100 neurons, with indices 0-899. I think there was a problem when calculating the SPIKE distance when not starting from index 0 with the original implementation, which should be fixed here. It works on my data but I haven't tested it extensively.

Cheers!

Richard