### PR TITLE
Indices for matrix slicing needs to be integers

### DIFF
--- a/pyspike/generic.py
+++ b/pyspike/generic.py
@@ -37,13 +37,13 @@ def _generic_profile_multi(spike_trains, pair_distance_func, indices=None):
         """
         L1 = len(pairs1)
         if L1 > 1:
-            dist_prof1 = divide_and_conquer(pairs1[:L1//2], pairs1[int(L1/2):])
+            dist_prof1 = divide_and_conquer(pairs1[:L1//2], pairs1[int(L1//2):])
         else:
             dist_prof1 = pair_distance_func(spike_trains[pairs1[0][0]],
                                             spike_trains[pairs1[0][1]])
         L2 = len(pairs2)
         if L2 > 1:
-            dist_prof2 = divide_and_conquer(pairs2[:L2//2], pairs2[int(L2/2):])
+            dist_prof2 = divide_and_conquer(pairs2[:L2//2], pairs2[int(L2//2):])
         else:
             dist_prof2 = pair_distance_func(spike_trains[pairs2[0][0]],
                                             spike_trains[pairs2[0][1]])

--- a/pyspike/generic.py
+++ b/pyspike/generic.py
@@ -37,13 +37,13 @@ def _generic_profile_multi(spike_trains, pair_distance_func, indices=None):
         """
         L1 = len(pairs1)
         if L1 > 1:
-            dist_prof1 = divide_and_conquer(pairs1[:int(L1/2)], pairs1[int(L1/2):])
+            dist_prof1 = divide_and_conquer(pairs1[:L1//2], pairs1[int(L1/2):])
         else:
             dist_prof1 = pair_distance_func(spike_trains[pairs1[0][0]],
                                             spike_trains[pairs1[0][1]])
         L2 = len(pairs2)
         if L2 > 1:
-            dist_prof2 = divide_and_conquer(pairs2[:int(L2/2)], pairs2[int(L2/2):])
+            dist_prof2 = divide_and_conquer(pairs2[:L2//2], pairs2[int(L2/2):])
         else:
             dist_prof2 = pair_distance_func(spike_trains[pairs2[0][0]],
                                             spike_trains[pairs2[0][1]])
@@ -63,8 +63,8 @@ def _generic_profile_multi(spike_trains, pair_distance_func, indices=None):
     L = len(pairs)
     if L > 1:
         # recursive iteration through the list of pairs to get average profile
-        avrg_dist = divide_and_conquer(pairs[:int(len(pairs)/2)],
-                                       pairs[int(len(pairs)/2):])
+        avrg_dist = divide_and_conquer(pairs[:len(pairs)//2],
+                                       pairs[len(pairs)//2:])
     else:
         avrg_dist = pair_distance_func(spike_trains[pairs[0][0]],
                                        spike_trains[pairs[0][1]])

--- a/pyspike/generic.py
+++ b/pyspike/generic.py
@@ -63,7 +63,7 @@ def _generic_profile_multi(spike_trains, pair_distance_func, indices=None):
     L = len(pairs)
     if L > 1:
         # recursive iteration through the list of pairs to get average profile
-        avrg_dist = divide_and_conquer(pairs[:int(len(pairs)/2]),
+        avrg_dist = divide_and_conquer(pairs[:int(len(pairs)/2)],
                                        pairs[int(len(pairs)/2):])
     else:
         avrg_dist = pair_distance_func(spike_trains[pairs[0][0]],

--- a/pyspike/generic.py
+++ b/pyspike/generic.py
@@ -37,13 +37,13 @@ def _generic_profile_multi(spike_trains, pair_distance_func, indices=None):
         """
         L1 = len(pairs1)
         if L1 > 1:
-            dist_prof1 = divide_and_conquer(pairs1[:L1/2], pairs1[L1/2:])
+            dist_prof1 = divide_and_conquer(pairs1[:int(L1/2)], pairs1[int(L1/2):])
         else:
             dist_prof1 = pair_distance_func(spike_trains[pairs1[0][0]],
                                             spike_trains[pairs1[0][1]])
         L2 = len(pairs2)
         if L2 > 1:
-            dist_prof2 = divide_and_conquer(pairs2[:L2/2], pairs2[L2/2:])
+            dist_prof2 = divide_and_conquer(pairs2[:int(L2/2)], pairs2[int(L2/2):])
         else:
             dist_prof2 = pair_distance_func(spike_trains[pairs2[0][0]],
                                             spike_trains[pairs2[0][1]])
@@ -63,8 +63,8 @@ def _generic_profile_multi(spike_trains, pair_distance_func, indices=None):
     L = len(pairs)
     if L > 1:
         # recursive iteration through the list of pairs to get average profile
-        avrg_dist = divide_and_conquer(pairs[:len(pairs)/2],
-                                       pairs[len(pairs)/2:])
+        avrg_dist = divide_and_conquer(pairs[:int(len(pairs)/2]),
+                                       pairs[int(len(pairs)/2):])
     else:
         avrg_dist = pair_distance_func(spike_trains[pairs[0][0]],
                                        spike_trains[pairs[0][1]])


### PR DESCRIPTION
Dividing the indices by 2 gives a float which cannot be used for slicing
the matrix. Changed the type of the indices to integer to ensure that
matrix slicing does not return error.