### PR TITLE
Remove Python 3.3 from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python:
  - "2.7"
- - "3.3"
  - "3.4"
  - "3.5"
  - "3.6"


### PR DESCRIPTION
Python 3.3 is not supported by scipy anymore. This removes Python 3.3 from the CI environments.