### PR TITLE
Make numpy_include conform to os.PathLike

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,11 +21,14 @@ else:
     use_cython = True
 
 
-class numpy_include(object):
+class numpy_include(os.PathLike):
     """Defers import of numpy until install_requires is through"""
     def __str__(self):
         import numpy
         return numpy.get_include()
+    
+    def __fspath__(self):
+        return str(self)
 
 
 if os.path.isfile("pyspike/cython/cython_add.c") and \


### PR DESCRIPTION
This is necessarily to support Cython 3. Cython 3 ends up passing the `numpy_include` instance directly to `os.path.join` Making `numpy_include` behave like an `os.PathLike` should allow `os.path.join` to work