### PR TITLE
Adapt numpy_include proxy for Cython 3 by making it an os.PathLike

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,9 +21,9 @@ else:
     use_cython = True
 
 
-class numpy_include(object):
+class numpy_include(os.PathLike):
     """Defers import of numpy until install_requires is through"""
-    def __str__(self):
+    def __fspath__(self):
         import numpy
         return numpy.get_include()
 


### PR DESCRIPTION
- Fixes #70.

As I was opening this PR, I noticed that the existing PR https://github.com/mariomulansky/PySpike/pull/68 solves the same problem, although it preserves the `__str__()` method rather than *replacing* it with `__fspath__()` as I do.

Please feel free to merge whichever version better suits your needs or aesthetic preferences.