### PR TITLE
Fix numpy include error with Cython 3 #68

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,10 +22,13 @@ else:
 
 
 class numpy_include(os.PathLike):
-    """Defers import of numpy until install_requires is through"""
-    def __fspath__(self):
-        import numpy
-        return numpy.get_include()
+     """Defers import of numpy until install_requires is through"""
+     def __str__(self):
+         import numpy
+         return numpy.get_include()
+
+     def __fspath__(self):
+         return str(self)
 
 
 if os.path.isfile("pyspike/cython/cython_add.c") and \


### PR DESCRIPTION
Fixes compilation error with Cython 3 by making `numpy_include` behave like an `os.PathLike`. That is needed because Cython 3 is passing the `numpy_include` instance directly to `os.path.join`.